### PR TITLE
Skipping lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You can:
 - register a pre flight check to determine whether or not a row has to be parsed
 - register a callback to handle each line
 - register a chopping map which transforms each row into an assiciative array
+- register a number of lines to skip at the top of the file
 
 
 ## Usage ##
@@ -76,7 +77,7 @@ This example ignores any line which md5 sum is `f23f81318ef24f1ba4df4781d79b7849
 
 ### Registering a callback ###
 
-Finally you can register a callback which is applied to each parsed line and allows you to process it.
+You can register a callback which is applied to each parsed line and allows you to process it.
 The closure gets the parsed line as an array and it is expected to return an array of the same format.
 
     $parser->setCallback(function(array $currentLine) {
@@ -84,3 +85,27 @@ The closure gets the parsed line as an array and it is expected to return an arr
                 return $currentLine;
             }
     );
+
+### Registering lines to skip ###
+
+Finally you, can register a certain number of lines to skip from the top of the parsed file. Just in case 
+the first lines introduce non-interesting information, like titles for the data or headers. Of course, you must do this before parsing.
+
+    $parser->setLinesToSkip(2);
+    $parser->parse();
+
+For a file like this:
+
+```
+Name                           Score
+______________________________ _____
+Jules                              8
+Fer                               10
+Albert                             5
+...
+```
+
+To unset the skips:
+
+    $parser->setLinesToSkip(0);
+    

--- a/library/Fanatique/Parser/FixedLengthFileParser.php
+++ b/library/Fanatique/Parser/FixedLengthFileParser.php
@@ -54,6 +54,9 @@ class FixedLengthFileParser implements ParserInterface
      */
     protected $content = array();
 
+    /** @var int $linesToSkip Amount of lines to skip */
+    protected $linesToSkip = 0;
+
     /**
      * Expects an array with n arrays containing :
      * 'field_name', 'start', 'length'
@@ -121,6 +124,17 @@ class FixedLengthFileParser implements ParserInterface
     public function getContent()
     {
         return $this->content;
+    }
+
+    /**
+     * Sets a certain amount of lines to skip at the top of the file
+     *
+     * @param int $lines Amount of lines to skip
+     * @return void
+     **/
+    public function setLinesToSkip(int $lines = 0)
+    {
+        $this->linesToSkip = $lines;
     }
 
     /**

--- a/library/Fanatique/Parser/FixedLengthFileParser.php
+++ b/library/Fanatique/Parser/FixedLengthFileParser.php
@@ -161,6 +161,14 @@ class FixedLengthFileParser implements ParserInterface
         //Parse file line by line
         $this->content = array();
         $filePointer = fopen($this->file, "r");
+
+        // skip as many lines as setted
+        $i = 0;
+        while ($i < $this->linesToSkip && !feof($filePointer)) {
+            fgets($filePointer, 4096);
+            $i++;
+        }
+
         while (!feof($filePointer)) {
             $buffer = fgets($filePointer, 4096);
 


### PR DESCRIPTION
Add to the parser the ability to skip lines from the top of the file, for cases like this:

```
Name                           Score
______________________________ _____
Jules                              8
Fer                               10
Albert                             5
...
```

where the 2 first lines are of no interest.